### PR TITLE
Add basic tokenizer

### DIFF
--- a/graceb/Makefile
+++ b/graceb/Makefile
@@ -1,0 +1,11 @@
+CC = gcc
+CFLAGS = -Iinclude -Wall -Wextra
+
+SRC = src/main.c src/lexer.c
+OUT = graceb
+
+all:
+	$(CC) $(CFLAGS) $(SRC) -o $(OUT)
+
+clean:
+	rm -f $(OUT)

--- a/graceb/include/tokens.h
+++ b/graceb/include/tokens.h
@@ -1,0 +1,21 @@
+#ifndef TOKENS_H
+#define TOKENS_H
+
+typedef enum {
+    TOKEN_EOF,
+    TOKEN_IDENTIFIER,
+    TOKEN_NUMBER,
+    TOKEN_STRING,
+    TOKEN_OPERATOR,
+    TOKEN_KEYWORD,
+    TOKEN_PUNCTUATION
+} TokenType;
+
+typedef struct {
+    TokenType type;
+    char*     lexeme;
+    int       line;
+    int       column;
+} Token;
+
+#endif // TOKENS_H

--- a/graceb/src/lexer.c
+++ b/graceb/src/lexer.c
@@ -1,0 +1,62 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <ctype.h>
+#include "../include/tokens.h"
+
+#define MAX_TOKENS 1024
+
+Token tokens[MAX_TOKENS];
+int token_count = 0;
+
+void add_token(TokenType type, const char* lexeme, int line, int column) {
+    if (token_count >= MAX_TOKENS) return;
+    tokens[token_count].type = type;
+    tokens[token_count].lexeme = strdup(lexeme);
+    tokens[token_count].line = line;
+    tokens[token_count].column = column;
+    token_count++;
+}
+
+void tokenize(const char* source) {
+    int line = 1, col = 1;
+    const char* p = source;
+
+    while (*p != '\0') {
+        if (isspace(*p)) {
+            if (*p == '\n') { line++; col = 1; }
+            else col++;
+            p++;
+            continue;
+        }
+
+        if (isalpha(*p)) {
+            const char* start = p;
+            while (isalnum(*p)) p++;
+            int len = p - start;
+            char* word = strndup(start, len);
+            add_token(TOKEN_IDENTIFIER, word, line, col);
+            col += len;
+            free(word);
+            continue;
+        }
+
+        if (isdigit(*p)) {
+            const char* start = p;
+            while (isdigit(*p)) p++;
+            int len = p - start;
+            char* num = strndup(start, len);
+            add_token(TOKEN_NUMBER, num, line, col);
+            col += len;
+            free(num);
+            continue;
+        }
+
+        // Single-char punctuation
+        char punct[2] = {*p, '\0'};
+        add_token(TOKEN_PUNCTUATION, punct, line, col);
+        p++; col++;
+    }
+
+    add_token(TOKEN_EOF, "EOF", line, col);
+}

--- a/graceb/src/main.c
+++ b/graceb/src/main.c
@@ -1,0 +1,42 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include "../include/tokens.h"
+
+extern Token tokens[];
+extern int token_count;
+void tokenize(const char* source);
+
+int main(int argc, char** argv) {
+    if (argc < 2) {
+        printf("Usage: graceb <file.b>\n");
+        return 1;
+    }
+
+    FILE* f = fopen(argv[1], "r");
+    if (!f) {
+        perror("Error opening file");
+        return 1;
+    }
+
+    fseek(f, 0, SEEK_END);
+    long size = ftell(f);
+    fseek(f, 0, SEEK_SET);
+    char* source = malloc(size + 1);
+    fread(source, 1, size, f);
+    source[size] = '\0';
+    fclose(f);
+
+    tokenize(source);
+
+    for (int i = 0; i < token_count; i++) {
+        printf("Token[%d]: %s (type %d) at line %d col %d\n",
+               i,
+               tokens[i].lexeme,
+               tokens[i].type,
+               tokens[i].line,
+               tokens[i].column);
+    }
+
+    free(source);
+    return 0;
+}

--- a/graceb/test.b
+++ b/graceb/test.b
@@ -1,0 +1,3 @@
+int main {
+  print 42
+}


### PR DESCRIPTION
## Summary
- create initial `graceb` tokenizer project
- implement token structures and lexer
- provide main entry to read `.b` files and print tokens
- add build instructions via Makefile

## Testing
- `make`
- `./graceb test.b`

------
https://chatgpt.com/codex/tasks/task_e_688a70769114832fa69bbc9d4874840e