### PR TITLE
Add variable declarations and symbol table

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,4 @@ dkms.conf
 
 # debug information files
 *.dwo
+graceb/graceb

--- a/graceb/Makefile
+++ b/graceb/Makefile
@@ -1,7 +1,7 @@
 CC = gcc
 CFLAGS = -Iinclude -Wall -Wextra
 
-SRC = src/main.c src/lexer.c src/parser.c src/ast_print.c
+SRC = src/main.c src/lexer.c src/parser.c src/ast_print.c src/symbol_table.c
 OUT = graceb
 
 all:

--- a/graceb/include/ast.h
+++ b/graceb/include/ast.h
@@ -4,11 +4,13 @@
 typedef enum {
     AST_INT_LITERAL,
     AST_IDENTIFIER,
-    AST_PRINT_STATEMENT
+    AST_PRINT_STATEMENT,
+    AST_VAR_DECL
 } ASTNodeType;
 
 typedef struct ASTNode {
     ASTNodeType type;
+    char* name;
     char* value;
     struct ASTNode* next;
 } ASTNode;

--- a/graceb/include/symbol_table.h
+++ b/graceb/include/symbol_table.h
@@ -1,0 +1,13 @@
+#ifndef SYMBOL_TABLE_H
+#define SYMBOL_TABLE_H
+
+typedef struct {
+    char* name;
+    char* value;
+} Symbol;
+
+void add_symbol(const char* name, const char* value);
+const char* get_symbol(const char* name);
+void free_symbols();
+
+#endif // SYMBOL_TABLE_H

--- a/graceb/include/tokens.h
+++ b/graceb/include/tokens.h
@@ -8,7 +8,8 @@ typedef enum {
     TOKEN_STRING,
     TOKEN_OPERATOR,
     TOKEN_KEYWORD,
-    TOKEN_PUNCTUATION
+    TOKEN_PUNCTUATION,
+    TOKEN_INT
 } TokenType;
 
 typedef struct {

--- a/graceb/src/ast_print.c
+++ b/graceb/src/ast_print.c
@@ -8,6 +8,9 @@ void print_ast(ASTNode* root) {
             case AST_PRINT_STATEMENT:
                 printf("PRINT: %s\n", root->value);
                 break;
+            case AST_VAR_DECL:
+                printf("VAR_DECL: int %s = %s\n", root->name, root->value);
+                break;
             case AST_INT_LITERAL:
                 printf("INT: %s\n", root->value);
                 break;
@@ -21,6 +24,7 @@ void print_ast(ASTNode* root) {
 void free_ast(ASTNode* root) {
     while (root) {
         ASTNode* next = root->next;
+        free(root->name);
         free(root->value);
         free(root);
         root = next;

--- a/graceb/src/lexer.c
+++ b/graceb/src/lexer.c
@@ -35,7 +35,11 @@ void tokenize(const char* source) {
             while (isalnum(*p)) p++;
             int len = p - start;
             char* word = strndup(start, len);
-            add_token(TOKEN_IDENTIFIER, word, line, col);
+            if (strcmp(word, "int") == 0) {
+                add_token(TOKEN_INT, word, line, col);
+            } else {
+                add_token(TOKEN_IDENTIFIER, word, line, col);
+            }
             col += len;
             free(word);
             continue;

--- a/graceb/src/main.c
+++ b/graceb/src/main.c
@@ -2,6 +2,7 @@
 #include <stdlib.h>
 #include "../include/tokens.h"
 #include "../include/ast.h"
+#include "../include/symbol_table.h"
 
 extern Token tokens[];
 extern int token_count;
@@ -41,6 +42,7 @@ int main(int argc, char** argv) {
     ASTNode* root = parse_tokens();
     print_ast(root);
     free_ast(root);
+    free_symbols();
 
     free(source);
     return 0;

--- a/graceb/src/parser.c
+++ b/graceb/src/parser.c
@@ -3,6 +3,7 @@
 #include <string.h>
 #include "../include/tokens.h"
 #include "../include/ast.h"
+#include "../include/symbol_table.h"
 
 extern Token tokens[];
 extern int token_count;
@@ -24,10 +25,30 @@ ASTNode* parse_tokens() {
     while (peek()->type != TOKEN_EOF) {
         Token* t = advance();
 
+        if (t->type == TOKEN_INT) {
+            Token* var = advance();
+            advance();
+            Token* val = advance();
+
+            ASTNode* node = malloc(sizeof(ASTNode));
+            node->type = AST_VAR_DECL;
+            node->name = strdup(var->lexeme);
+            node->value = strdup(val->lexeme);
+            node->next = NULL;
+
+            add_symbol(node->name, node->value);
+
+            if (!head) head = node;
+            else tail->next = node;
+            tail = node;
+            continue;
+        }
+
         if (strcmp(t->lexeme, "print") == 0) {
             Token* next = advance();
             ASTNode* node = malloc(sizeof(ASTNode));
             node->type = AST_PRINT_STATEMENT;
+            node->name = NULL;
             node->value = strdup(next->lexeme);
             node->next = NULL;
 

--- a/graceb/src/symbol_table.c
+++ b/graceb/src/symbol_table.c
@@ -1,0 +1,32 @@
+#include <stdlib.h>
+#include <string.h>
+#include "../include/symbol_table.h"
+
+#define MAX_SYMBOLS 256
+
+static Symbol symbols[MAX_SYMBOLS];
+static int symbol_count = 0;
+
+void add_symbol(const char* name, const char* value) {
+    if (symbol_count >= MAX_SYMBOLS) return;
+    symbols[symbol_count].name = strdup(name);
+    symbols[symbol_count].value = strdup(value);
+    symbol_count++;
+}
+
+const char* get_symbol(const char* name) {
+    for (int i = 0; i < symbol_count; i++) {
+        if (strcmp(symbols[i].name, name) == 0) {
+            return symbols[i].value;
+        }
+    }
+    return NULL;
+}
+
+void free_symbols() {
+    for (int i = 0; i < symbol_count; i++) {
+        free(symbols[i].name);
+        free(symbols[i].value);
+    }
+    symbol_count = 0;
+}

--- a/graceb/test.b
+++ b/graceb/test.b
@@ -1,2 +1,2 @@
-print 42
-print 99
+int x = 10
+print x


### PR DESCRIPTION
## Summary
- add `TOKEN_INT` token in lexer
- support `int` declarations in parser and AST
- track variables in a simple symbol table
- print variable declarations in AST output
- ignore built binary
- update sample program

## Testing
- `make clean && make && ./graceb test.b`

------
https://chatgpt.com/codex/tasks/task_e_688a7363fbc8832fad30f5125de20d78