### PR TITLE
Implement arithmetic expressions in parser

### DIFF
--- a/graceb/include/ast.h
+++ b/graceb/include/ast.h
@@ -4,6 +4,7 @@
 typedef enum {
     AST_INT_LITERAL,
     AST_IDENTIFIER,
+    AST_BINARY_EXPR,
     AST_PRINT_STATEMENT,
     AST_VAR_DECL
 } ASTNodeType;
@@ -12,11 +13,15 @@ typedef struct ASTNode {
     ASTNodeType type;
     char* name;
     char* value;
+    char op;
+    struct ASTNode* left;
+    struct ASTNode* right;
     struct ASTNode* next;
 } ASTNode;
 
 ASTNode* parse_tokens();
 void print_ast(ASTNode* root);
 void free_ast(ASTNode* root);
+int evaluate(ASTNode* node);
 
 #endif // AST_H

--- a/graceb/src/ast_print.c
+++ b/graceb/src/ast_print.c
@@ -3,6 +3,27 @@
 #include "../include/ast.h"
 #include "../include/symbol_table.h"
 
+int evaluate(ASTNode* node) {
+    if (!node) return 0;
+    switch (node->type) {
+        case AST_INT_LITERAL:
+            return atoi(node->value);
+        case AST_IDENTIFIER: {
+            const char* val = lookup_symbol(node->name);
+            return val ? atoi(val) : 0;
+        }
+        case AST_BINARY_EXPR: {
+            int l = evaluate(node->left);
+            int r = evaluate(node->right);
+            if (node->op == '+') return l + r;
+            if (node->op == '-') return l - r;
+            return 0;
+        }
+        default:
+            return 0;
+    }
+}
+
 void print_ast(ASTNode* root) {
     while (root) {
         switch (root->type) {
@@ -22,6 +43,11 @@ void print_ast(ASTNode* root) {
             case AST_INT_LITERAL:
                 printf("INT: %s\n", root->value);
                 break;
+            case AST_BINARY_EXPR: {
+                int v = evaluate(root);
+                printf("BIN_EXPR: %d\n", v);
+                break;
+            }
             default:
                 printf("UNKNOWN AST NODE\n");
         }
@@ -29,12 +55,19 @@ void print_ast(ASTNode* root) {
     }
 }
 
+static void free_node(ASTNode* node) {
+    if (!node) return;
+    free_node(node->left);
+    free_node(node->right);
+    free(node->name);
+    free(node->value);
+    free(node);
+}
+
 void free_ast(ASTNode* root) {
     while (root) {
         ASTNode* next = root->next;
-        free(root->name);
-        free(root->value);
-        free(root);
+        free_node(root);
         root = next;
     }
 }

--- a/graceb/src/parser.c
+++ b/graceb/src/parser.c
@@ -18,6 +18,43 @@ static Token* advance() {
     return &tokens[current++];
 }
 
+static ASTNode* parse_primary() {
+    Token* t = advance();
+    ASTNode* node = malloc(sizeof(ASTNode));
+    memset(node, 0, sizeof(ASTNode));
+
+    if (t->type == TOKEN_NUMBER) {
+        node->type = AST_INT_LITERAL;
+        node->value = strdup(t->lexeme);
+    } else if (t->type == TOKEN_IDENTIFIER) {
+        node->type = AST_IDENTIFIER;
+        node->name = strdup(t->lexeme);
+    } else {
+        free(node);
+        return NULL;
+    }
+
+    return node;
+}
+
+static ASTNode* parse_expression() {
+    ASTNode* left = parse_primary();
+    while (peek()->type == TOKEN_PUNCTUATION &&
+           (strcmp(peek()->lexeme, "+") == 0 || strcmp(peek()->lexeme, "-") == 0)) {
+        char op = peek()->lexeme[0];
+        advance();
+        ASTNode* right = parse_primary();
+        ASTNode* expr = malloc(sizeof(ASTNode));
+        memset(expr, 0, sizeof(ASTNode));
+        expr->type = AST_BINARY_EXPR;
+        expr->op = op;
+        expr->left = left;
+        expr->right = right;
+        left = expr;
+    }
+    return left;
+}
+
 ASTNode* parse_tokens() {
     ASTNode* head = NULL;
     ASTNode* tail = NULL;
@@ -28,12 +65,18 @@ ASTNode* parse_tokens() {
         if (t->type == TOKEN_INT) {
             Token* var = advance();
             advance();
-            Token* val = advance();
+            ASTNode* expr = parse_expression();
+
+            int result = evaluate(expr);
+            char buffer[64];
+            snprintf(buffer, sizeof(buffer), "%d", result);
 
             ASTNode* node = malloc(sizeof(ASTNode));
+            memset(node, 0, sizeof(ASTNode));
             node->type = AST_VAR_DECL;
             node->name = strdup(var->lexeme);
-            node->value = strdup(val->lexeme);
+            node->value = strdup(buffer);
+            node->left = expr;
             node->next = NULL;
 
             add_symbol(node->name, node->value);
@@ -47,6 +90,7 @@ ASTNode* parse_tokens() {
         if (strcmp(t->lexeme, "print") == 0) {
             Token* next = advance();
             ASTNode* node = malloc(sizeof(ASTNode));
+            memset(node, 0, sizeof(ASTNode));
             node->type = AST_PRINT_STATEMENT;
             node->name = strdup(next->lexeme);
             node->value = NULL;


### PR DESCRIPTION
## Summary
- extend AST node types to include binary expressions
- implement expression parsing in parser
- evaluate expression trees during variable declaration
- handle binary expressions in AST print and free routines

## Testing
- `make -C graceb`
- `./graceb/graceb graceb/test.b`

------
https://chatgpt.com/codex/tasks/task_e_688a7650fdb4832fa898bcc8d1dd5fda