### PR TITLE
Add while loop support

### DIFF
--- a/graceb/include/ast.h
+++ b/graceb/include/ast.h
@@ -7,7 +7,8 @@ typedef enum {
     AST_BINARY_EXPR,
     AST_PRINT_STATEMENT,
     AST_VAR_DECL,
-    AST_IF_STATEMENT
+    AST_IF_STATEMENT,
+    AST_WHILE_STATEMENT
 } ASTNodeType;
 
 typedef struct ASTNode {

--- a/graceb/include/tokens.h
+++ b/graceb/include/tokens.h
@@ -10,7 +10,8 @@ typedef enum {
     TOKEN_KEYWORD,
     TOKEN_PUNCTUATION,
     TOKEN_INT,
-    TOKEN_IF
+    TOKEN_IF,
+    TOKEN_WHILE
 } TokenType;
 
 typedef struct {

--- a/graceb/src/ast_print.c
+++ b/graceb/src/ast_print.c
@@ -57,6 +57,14 @@ void print_ast(ASTNode* root) {
             }
             break;
         }
+        case AST_WHILE_STATEMENT: {
+            int cond = evaluate(root->left);
+            printf("WHILE (%d)\n", cond);
+            while (evaluate(root->left)) {
+                print_ast(root->right);
+            }
+            break;
+        }
         default:
             printf("UNKNOWN AST NODE\n");
         }

--- a/graceb/src/lexer.c
+++ b/graceb/src/lexer.c
@@ -39,6 +39,8 @@ void tokenize(const char* source) {
                 add_token(TOKEN_INT, word, line, col);
             } else if (strcmp(word, "if") == 0) {
                 add_token(TOKEN_IF, word, line, col);
+            } else if (strcmp(word, "while") == 0) {
+                add_token(TOKEN_WHILE, word, line, col);
             } else {
                 add_token(TOKEN_IDENTIFIER, word, line, col);
             }

--- a/graceb/src/parser.c
+++ b/graceb/src/parser.c
@@ -114,6 +114,20 @@ static ASTNode* parse_statement() {
         return node;
     }
 
+    if (t->type == TOKEN_WHILE || (t->type == TOKEN_IDENTIFIER && strcmp(t->lexeme, "while") == 0)) {
+        ASTNode* condition = parse_expression();
+        ASTNode* body = parse_statement();
+
+        ASTNode* node = malloc(sizeof(ASTNode));
+        memset(node, 0, sizeof(ASTNode));
+        node->type = AST_WHILE_STATEMENT;
+        node->left = condition;
+        node->right = body;
+        node->next = NULL;
+
+        return node;
+    }
+
     if (strcmp(t->lexeme, "print") == 0) {
         Token* next = advance();
         ASTNode* node = malloc(sizeof(ASTNode));

--- a/graceb/test_while.b
+++ b/graceb/test_while.b
@@ -1,0 +1,3 @@
+int x = 0
+while x == 0
+  print x


### PR DESCRIPTION
## Summary
- add a new TOKEN_WHILE and AST_WHILE_STATEMENT type
- extend lexer and parser to understand `while` loops
- update AST printer to repeatedly execute body while condition is true
- provide a sample `test_while.b` demonstrating looping

## Testing
- `make clean && make`
- `timeout 1 ./graceb test_while.b > /tmp/out && head -n 7 /tmp/out`
- `tail -n 6 /tmp/out`


------
https://chatgpt.com/codex/tasks/task_e_688a7a36325c832f96950dbb70851511