### PR TITLE
Add else support for Grace-B

### DIFF
--- a/graceb/include/ast.h
+++ b/graceb/include/ast.h
@@ -18,6 +18,7 @@ typedef struct ASTNode {
     char op;
     struct ASTNode* left;
     struct ASTNode* right;
+    struct ASTNode* else_branch;
     struct ASTNode* next;
 } ASTNode;
 

--- a/graceb/include/tokens.h
+++ b/graceb/include/tokens.h
@@ -11,6 +11,7 @@ typedef enum {
     TOKEN_PUNCTUATION,
     TOKEN_INT,
     TOKEN_IF,
+    TOKEN_ELSE,
     TOKEN_WHILE
 } TokenType;
 

--- a/graceb/src/ast_print.c
+++ b/graceb/src/ast_print.c
@@ -54,6 +54,8 @@ void print_ast(ASTNode* root) {
             printf("IF (%d)\n", cond);
             if (cond) {
                 print_ast(root->right);
+            } else if (root->else_branch) {
+                print_ast(root->else_branch);
             }
             break;
         }
@@ -76,6 +78,7 @@ static void free_node(ASTNode* node) {
     if (!node) return;
     free_node(node->left);
     free_node(node->right);
+    free_node(node->else_branch);
     free(node->name);
     free(node->value);
     free(node);

--- a/graceb/src/lexer.c
+++ b/graceb/src/lexer.c
@@ -39,6 +39,8 @@ void tokenize(const char* source) {
                 add_token(TOKEN_INT, word, line, col);
             } else if (strcmp(word, "if") == 0) {
                 add_token(TOKEN_IF, word, line, col);
+            } else if (strcmp(word, "else") == 0) {
+                add_token(TOKEN_ELSE, word, line, col);
             } else if (strcmp(word, "while") == 0) {
                 add_token(TOKEN_WHILE, word, line, col);
             } else {

--- a/graceb/src/parser.c
+++ b/graceb/src/parser.c
@@ -103,12 +103,19 @@ static ASTNode* parse_statement() {
     if (t->type == TOKEN_IF || (t->type == TOKEN_IDENTIFIER && strcmp(t->lexeme, "if") == 0)) {
         ASTNode* condition = parse_expression();
         ASTNode* body = parse_statement();
+        ASTNode* else_body = NULL;
+        if (peek()->type == TOKEN_ELSE ||
+            (peek()->type == TOKEN_IDENTIFIER && strcmp(peek()->lexeme, "else") == 0)) {
+            advance();
+            else_body = parse_statement();
+        }
 
         ASTNode* node = malloc(sizeof(ASTNode));
         memset(node, 0, sizeof(ASTNode));
         node->type = AST_IF_STATEMENT;
         node->left = condition;
         node->right = body;
+        node->else_branch = else_body;
         node->next = NULL;
 
         return node;

--- a/graceb/test_else.b
+++ b/graceb/test_else.b
@@ -1,0 +1,5 @@
+int x = 5
+if x == 10
+  print 100
+else
+  print 200


### PR DESCRIPTION
## Summary
- extend tokens with `TOKEN_ELSE`
- recognize `else` in the lexer
- support optional `else` blocks in AST and parser
- execute else blocks in the AST printer/evaluator
- add example `test_else.b`

## Testing
- `cd graceb && make clean && make`
- `./graceb test_else.b`

------
https://chatgpt.com/codex/tasks/task_e_688a7c390c84832fb0fa3ba200405749